### PR TITLE
Strict email validation. (no spaces and email format xxx@xxx.xxx). Tag to 1.2.5.

### DIFF
--- a/RVValidator.podspec.json
+++ b/RVValidator.podspec.json
@@ -1,6 +1,6 @@
 {
     "name": "RVValidator",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "summary": "Laravel validator like for iOS",
     "license": "MIT",
     "platforms": {
@@ -8,7 +8,7 @@
     },
     "source": {
         "git": "https://github.com/BadChoice/RVValidator.git",
-        "tag": "1.2.4"
+        "tag": "1.2.5"
     },
     "dependencies":{
         "Collection": [

--- a/RVValidator/lib/rules/RVRuleEmail.m
+++ b/RVValidator/lib/rules/RVRuleEmail.m
@@ -12,11 +12,8 @@
 
 -(BOOL)performValidation:(NSString*)text{
     if( [self isEmptyString:text] ) return true;
-    
-    BOOL stricterFilter     = NO; // Discussion http://blog.logichigh.com/2010/09/02/validating-an-e-mail-address/
-    NSString *stricterFilterString = @"^[A-Z0-9a-z\\._%+-]+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2,4}$";
-    NSString *laxString     = @"^.+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2}[A-Za-z]*$";
-    NSString *emailRegex    = stricterFilter ? stricterFilterString : laxString;
+
+    NSString *emailRegex    = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}";
     NSPredicate *emailTest  = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", emailRegex];
     
     BOOL valid = [emailTest evaluateWithObject:text];


### PR DESCRIPTION
Linear Parent task: https://linear.app/revo/issue/REV-5249/notificacio-de-les-trials-falla

@BadChoice abans q m'has comentat q el stricterFilterString donava problemes amb els mails revo.works... segurament seria per la part final ({2,4}$) q màxim deixa 4 lletres despres del "." i works en té 5.

Treu versió pls


Reviewer: @PauRevo 